### PR TITLE
Support for :app_id

### DIFF
--- a/lib/pusher-fake/configuration.rb
+++ b/lib/pusher-fake/configuration.rb
@@ -1,5 +1,8 @@
 module PusherFake
   class Configuration
+    # @return [String] The Pusher Applicaiton ID. (Defaults to +PUSHER_APP_ID+.)
+    attr_accessor :app_id
+    
     # @return [String] The Pusher API key. (Defaults to +PUSHER_API_KEY+.)
     attr_accessor :key
 
@@ -20,6 +23,7 @@ module PusherFake
 
     # Instantiated from {PusherFake.configuration}. Sets the defaults.
     def initialize
+      self.app_id      = "PUSHER_APP_ID"
       self.key         = "PUSHER_API_KEY"
       self.secret      = "PUSHER_API_SECRET"
       self.socket_host = "127.0.0.1"

--- a/lib/pusher-fake/server/application.rb
+++ b/lib/pusher-fake/server/application.rb
@@ -18,7 +18,7 @@ module PusherFake
       #
       # @return [String] The channel name.
       def self.channel
-        path.match(%r{/apps/PUSHER_APP_ID/channels/(.+)/events}i)[1]
+        path.match(%r{/apps/#{PusherFake.configuration.app_id}/channels/(.+)/events}i)[1]
       end
 
       # Parse and return the event data from the request JSON.

--- a/spec/lib/pusher-fake/configuration_spec.rb
+++ b/spec/lib/pusher-fake/configuration_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe PusherFake::Configuration do
+  it { should have_configuration_option(:app_id).with_default("PUSHER_APP_ID") }
   it { should have_configuration_option(:key).with_default("PUSHER_API_KEY") }
   it { should have_configuration_option(:secret).with_default("PUSHER_API_SECRET") }
   it { should have_configuration_option(:socket_host).with_default("127.0.0.1") }

--- a/spec/lib/pusher-fake/server/application_spec.rb
+++ b/spec/lib/pusher-fake/server/application_spec.rb
@@ -60,6 +60,17 @@ describe PusherFake::Server::Application, ".channel" do
   it "returns the channel name from the path" do
     subject.channel.should == channel
   end
+  
+  context "with a custom application ID" do
+    before do
+      PusherFake.configuration.app_id = 'test-id'
+    end
+    let(:path) { "/apps/test-id/channels/#{channel}/events" }
+    
+    it "returns the channel name from the path" do
+      subject.channel.should == channel
+    end
+  end
 end
 
 describe PusherFake::Server::Application, ".data" do


### PR DESCRIPTION
The `app_id` seems to be hardcoded to the string `PUSHER_APP_ID`. Better to make it parametric, same as `key` or `secret`.
