### PR TITLE
make subscription_data match pusher 1.11 format

### DIFF
--- a/features/channel_presence.feature
+++ b/features/channel_presence.feature
@@ -19,3 +19,11 @@ Feature: Client on a presence channel
     Then I should see 2 clients
     When Bob unsubscribes from the "presence-game-1" channel
     Then I should see 1 client
+
+  Scenario: Subscribing client should receive User info
+    Given Bob is connected
+    And Bob is subscribed to the "presence-game-1" channel
+    When I subscribe to the "presence-game-1" channel with presence events
+    Then I should see 2 clients with name "Alan Turing"
+    
+    

--- a/features/step_definitions/channel_steps.rb
+++ b/features/step_definitions/channel_steps.rb
@@ -26,6 +26,7 @@ When %{I subscribe to the "$channel" channel with presence events} do |channel|
         var
         element = list.appendChild(document.createElement("li"));
         element.setAttribute("id", "client-" + client.id);
+        element.innerHTML = client.info && client.info.name
       });
     });
     channel.bind("pusher:member_added", function(client) {
@@ -34,6 +35,7 @@ When %{I subscribe to the "$channel" channel with presence events} do |channel|
       var
       element = list.appendChild(document.createElement("li"));
       element.setAttribute("id", "client-" + client.id);
+      element.innerHTML = client.info && client.info.name
     });
     channel.bind("pusher:member_removed", function(client) {
       var item = list.querySelector("li#client-" + client.id);

--- a/features/step_definitions/presence_steps.rb
+++ b/features/step_definitions/presence_steps.rb
@@ -1,6 +1,6 @@
-Then /^I should see (\d+) clients?$/ do |count|
+Then /^I should see (\d+) clients?(?: with name "([^"]+)")?$/ do |count, name|
   within("#presence") do
     should have_css("header h1 span", text: count)
-    should have_css("ul li", count: count.to_i)
+    should have_css("ul li:contains('#{name}')", count: count.to_i)
   end
 end

--- a/features/support/application.rb
+++ b/features/support/application.rb
@@ -19,7 +19,7 @@ class Sinatra::Application
     channel = Pusher[params[:channel_name]]
 
     if params[:channel_name] =~ /^presence-/
-      data = { user_id: params[:socket_id], user_info: {} }
+      data = { user_id: params[:socket_id], user_info: { name: "Alan Turing"} }
     end
 
     channel.authenticate(params[:socket_id], data).to_json

--- a/lib/pusher-fake/channel/presence.rb
+++ b/lib/pusher-fake/channel/presence.rb
@@ -28,18 +28,17 @@ module PusherFake
       def subscription_data
         hash = Hash[
           members.map { |_, member|
-            [member[:user_id], member]
+#            [member[:user_id], member]
+             [member[:user_id], member[:user_info]]
           }
         ]
-
-        { presence: { hash: hash, count: members.size } }
+        { presence: { hash: hash, count: members.size, ids: members.map { |_,m| m[:user_id] } } }
       end
 
       private
 
       def subscription_succeeded(connection, options = {})
         members[connection] = Yajl::Parser.parse(options[:channel_data], symbolize_keys: true)
-
         emit("pusher_internal:member_added", members[connection])
 
         super

--- a/spec/lib/pusher-fake/channel/presence_spec.rb
+++ b/spec/lib/pusher-fake/channel/presence_spec.rb
@@ -114,8 +114,9 @@ describe PusherFake::Channel::Presence, "#subscription_data" do
   it "returns hash with presence information" do
     subject.subscription_data.should == {
       presence: {
-        hash:  { member[:user_id] => member },
-        count: 1
+        hash:  { member[:user_id] => member[:user_info] },
+        count: 1,
+        ids: [ member[:user_id] ]
       }
     }
   end
@@ -125,8 +126,9 @@ describe PusherFake::Channel::Presence, "#subscription_data" do
 
     subject.subscription_data.should == {
       presence: {
-        hash:  { member[:user_id] => member, other[:user_id] => other },
-        count: 2
+        hash:  { member[:user_id] => member[:user_info], other[:user_id] => other[:user_info] },
+        count: 2,
+        ids: [member[:user_id], other[:user_id]]
       }
     }
   end


### PR DESCRIPTION
I was having a problem with pusher-fake where the optional user_info parameter was not getting passed through properly on the subscription_succeeded event for presence channels.  Looking at what was being sent it appears the subscription_data format was not correct for pusher 1.11.0 -  It might have been correct for a previous version, not sure.  I believe this patch updates it to match what pusher.js 1.11.0 expects
