### PR TITLE
client events dont get sent to the originator

### DIFF
--- a/features/channel_trigger.feature
+++ b/features/channel_trigger.feature
@@ -49,7 +49,7 @@ Feature: Triggering events on a channel
     Given I am subscribed to the "private-chat" channel
     And Bob is subscribed to the "private-chat" channel
     When I trigger the "client-message" event on the "private-chat" channel
-    Then I should receive a "client-message" event on the "private-chat" channel
+    Then I should not receive a "client-message" event on the "private-chat" channel
     And Bob should receive a "client-message" event on the "private-chat" channel
 
   Scenario: Client triggers a client event on a previously subscribed private channel

--- a/lib/pusher-fake/channel/public.rb
+++ b/lib/pusher-fake/channel/public.rb
@@ -27,9 +27,9 @@ module PusherFake
       #
       # @param [String] event The event name.
       # @param [Hash] data The event data.
-      def emit(event, data)
+      def emit(event, data, connection_to_skip=nil)
         connections.each do |connection|
-          connection.emit(event, data, name)
+          connection.emit(event, data, name) unless connection==connection_to_skip
         end
       end
 

--- a/lib/pusher-fake/connection.rb
+++ b/lib/pusher-fake/connection.rb
@@ -47,7 +47,7 @@ module PusherFake
         return unless channel.is_a?(Channel::Private)
         return unless channel.includes?(self)
 
-        channel.emit(event, data)
+        channel.emit(event, data, self)
       end
     end
   end

--- a/spec/lib/pusher-fake/connection_spec.rb
+++ b/spec/lib/pusher-fake/connection_spec.rb
@@ -145,7 +145,7 @@ describe PusherFake::Connection, "#process, with a client event" do
   it "emits the event to the channel when the connection is in the channel" do
     channel.stubs(includes?: true)
     subject.process(json)
-    channel.should have_received(:emit).with(event, data)
+    channel.should have_received(:emit).with(event, data, subject)
   end
 
   it "does not emit the event to the channel when the channel is not private" do


### PR DESCRIPTION
According to the pusher docs, client triggered events do not get sent back to the originator
