### PR TITLE
Handle pusher:ping events from client

### DIFF
--- a/lib/pusher-fake/connection.rb
+++ b/lib/pusher-fake/connection.rb
@@ -37,13 +37,16 @@ module PusherFake
       message = MultiJson.load(data, symbolize_keys: true)
       data    = message[:data]
       event   = message[:event]
-      channel = Channel.factory(message[:channel] || data.delete(:channel))
+      name    = message[:channel] || data.delete(:channel)
+      channel = Channel.factory(name) if name
 
       case event
       when "pusher:subscribe"
         channel.add(self, data)
       when "pusher:unsubscribe"
         channel.remove(self)
+      when "pusher:ping"
+        emit("pusher:pong")
       when CLIENT_EVENT_MATCHER
         if channel.is_a?(Channel::Private) && channel.includes?(self)
           channel.emit(event, data, socket_id: socket.object_id)

--- a/spec/lib/pusher-fake/connection_spec.rb
+++ b/spec/lib/pusher-fake/connection_spec.rb
@@ -118,6 +118,37 @@ describe PusherFake::Connection, "#process, with an unsubscribe event" do
   end
 end
 
+describe PusherFake::Connection, "#process, with a ping event" do
+  let(:json)    { stub }
+  let(:message) { { event: "pusher:ping", data: {} } }
+
+  subject { PusherFake::Connection.new(stub) }
+
+  before do
+    MultiJson.stubs(load: message)
+    PusherFake::Channel.stubs(:factory)
+    subject.stubs(:emit)
+  end
+
+  it "parses the JSON data" do
+    subject.process(json)
+
+    expect(MultiJson).to have_received(:load).with(json, symbolize_keys: true)
+  end
+
+  it "creates no channels" do
+    subject.process(json)
+
+    expect(PusherFake::Channel).to have_received(:factory).never
+  end
+
+  it "emits a pong event" do
+    subject.process(json)
+
+    expect(subject).to have_received(:emit).with("pusher:pong")
+  end
+end
+
 describe PusherFake::Connection, "#process, with a client event" do
   let(:data)    { {} }
   let(:json)    { stub }


### PR DESCRIPTION
Necessary to stop connections from timing out after 2.5 minutes. This was triggering member_removed on presence channels, which was a little problem for us.
