### PR TITLE
Added support for batch trigger events

### DIFF
--- a/lib/pusher-fake/server/application.rb
+++ b/lib/pusher-fake/server/application.rb
@@ -51,6 +51,28 @@ module PusherFake
       end
       # rubocop:enable Style/RescueModifier
 
+      # Emit a batch event with data to the requested channel(s).
+      #
+      # @param [Rack::Request] request The HTTP request.
+      # @return [Hash] An empty hash.
+      #
+      # rubocop:disable Style/RescueModifier
+      def self.batch_events(request)
+        batch = MultiJson.load(request.body.read)["batch"]
+
+        batch.each do |event|
+          data = MultiJson.load(event["data"]) rescue event["data"]
+
+          event["channels"].each do |channel_name|
+            channel = Channel.factory(channel_name)
+            channel.emit(event["name"], data, socket_id: event["socket_id"])
+          end
+        end
+
+        {}
+      end
+      # rubocop:enable Style/RescueModifier
+
       # Return a hash of channel information.
       #
       # Occupied status is always included. A user count may be requested for

--- a/lib/pusher-fake/server/application.rb
+++ b/lib/pusher-fake/server/application.rb
@@ -42,6 +42,7 @@ module PusherFake
         event = MultiJson.load(request.body.read)
         data  = MultiJson.load(event["data"]) rescue event["data"]
 
+        event["channels"] ||= [event["channel"]]
         event["channels"].each do |channel_name|
           channel = Channel.factory(channel_name)
           channel.emit(event["name"], data, socket_id: event["socket_id"])
@@ -56,13 +57,14 @@ module PusherFake
       # @param [Rack::Request] request The HTTP request.
       # @return [Hash] An empty hash.
       #
-      # rubocop:disable Style/RescueModifier
+      # rubocop:disable Style/RescueModifier, Metrics/AbcSize
       def self.batch_events(request)
         batch = MultiJson.load(request.body.read)["batch"]
 
         batch.each do |event|
           data = MultiJson.load(event["data"]) rescue event["data"]
 
+          event["channels"] ||= [event["channel"]]
           event["channels"].each do |channel_name|
             channel = Channel.factory(channel_name)
             channel.emit(event["name"], data, socket_id: event["socket_id"])
@@ -71,7 +73,7 @@ module PusherFake
 
         {}
       end
-      # rubocop:enable Style/RescueModifier
+      # rubocop:enable Style/RescueModifier, Metrics/AbcSize
 
       # Return a hash of channel information.
       #

--- a/lib/pusher-fake/server/application.rb
+++ b/lib/pusher-fake/server/application.rb
@@ -13,6 +13,7 @@ module PusherFake
 
       REQUEST_PATHS = {
         %r{\A/apps/:id/events\z}                 => :events,
+        %r{\A/apps/:id/batch_events\z}           => :batch_events,
         %r{\A/apps/:id/channels\z}               => :channels,
         %r{\A/apps/:id/channels/([^/]+)\z}       => :channel,
         %r{\A/apps/:id/channels/([^/]+)/users\z} => :users

--- a/spec/lib/pusher-fake/server/application_spec.rb
+++ b/spec/lib/pusher-fake/server/application_spec.rb
@@ -66,6 +66,24 @@ describe PusherFake::Server::Application, ".call, for triggering events" do
 end
 
 describe PusherFake::Server::Application,
+         ".call, for triggering batch events" do
+  it_should_behave_like "an API request" do
+    let(:id)   { PusherFake.configuration.app_id }
+    let(:path) { "/apps/#{id}/batch_events" }
+
+    before do
+      allow(subject).to receive(:batch_events).and_return(hash)
+    end
+
+    it "emits batch events" do
+      subject.call(environment)
+
+      expect(subject).to have_received(:batch_events).with(request)
+    end
+  end
+end
+
+describe PusherFake::Server::Application,
          ".call, retrieving occupied channels" do
   it_should_behave_like "an API request" do
     let(:id)   { PusherFake.configuration.app_id }


### PR DESCRIPTION
Pusher supports sending batch events since version 1.1.0 of their Ruby gem. I added in an endpoint for the fake server so that Rails applications can make use of this in testing.

See the [API documentation](https://pusher.com/docs/rest_api#method-post-batch-events).