### PR TITLE
Call `to_s` on the app_id

### DIFF
--- a/lib/pusher-fake/server/application.rb
+++ b/lib/pusher-fake/server/application.rb
@@ -110,7 +110,7 @@ module PusherFake
       # @param [Rack::Request] request The HTTP request.
       # @return [Hash] A response hash.
       def self.response_for(request)
-        id = PusherFake.configuration.app_id
+        id = PusherFake.configuration.app_id.to_s
 
         REQUEST_PATHS.each do |path, method|
           matcher = Regexp.new(path.to_s.sub(":id", id))


### PR DESCRIPTION
I have an old Pusher id that happens to be numeric. Setting that in my YAML config I get a very unhelpful error message from inside pusher-fake: "Bad request: no implicit conversion of Integer into String" 

By calling to_s on this my old fashioned numeric id works as intended.