### PR TITLE
Fix connection ID for ruby 2.7.

### DIFF
--- a/lib/pusher-fake/connection.rb
+++ b/lib/pusher-fake/connection.rb
@@ -21,7 +21,7 @@ module PusherFake
     # @return [Integer] The object ID of the socket.
     def id
       parts = socket.object_id.to_s.split("")
-      parts = parts.each_slice(parts.length / 2).to_a
+      parts = parts.each_slice((parts.length / 2.0).ceil).to_a
 
       [parts.first.join(""), parts.last.join("")].join(".")
     end

--- a/spec/lib/pusher-fake/connection_spec.rb
+++ b/spec/lib/pusher-fake/connection_spec.rb
@@ -97,8 +97,8 @@ end
 describe PusherFake::Connection, "#id" do
   subject { described_class.new(socket) }
 
-  let(:id)     { "123.456" }
-  let(:socket) { instance_double(Object, object_id: 123_456) }
+  let(:id)     { "1234.567" }
+  let(:socket) { instance_double(Object, object_id: 1_234_567) }
 
   it "returns the object ID of the socket" do
     expect(subject.id).to eq(id)


### PR DESCRIPTION
Ruby 2.7 Object#object_id can return numbers with an odd number of decimal digits. This would lead to a bunch of connections with the same socket ID value.