### PR TITLE
Switch to using threads instead of processes for the PusherFake server

### DIFF
--- a/lib/pusher-fake/support/base.rb
+++ b/lib/pusher-fake/support/base.rb
@@ -26,6 +26,5 @@ PusherFake.configuration.web_options.tap do |options|
 end
 
 # Start the fake socket and web servers.
-fork { PusherFake::Server.start }.tap do |id|
-  at_exit { Process.kill("KILL", id) }
-end
+thread = Thread.new { PusherFake::Server.start }
+at_exit { Thread.kill(thread) }


### PR DESCRIPTION
`fork` is not supported on Windows, whereas threads are. In a project I'm working on, we run `require 'pusher-fake/support/rspec'` in a spec helper. This works on macOS/Linux, but it fails on Windows due to the usage of `fork`. I believe the end result of this code is the same as using a separate process, but this approach is supported on more platforms. Anyway, it seems to get past that failure on a Windows machine now!