### PR TITLE
Patch EventMachine and Thin to call existing trap handlers

### DIFF
--- a/lib/pusher-fake/extensions/parent_trap.rb
+++ b/lib/pusher-fake/extensions/parent_trap.rb
@@ -1,0 +1,17 @@
+module PusherFake
+  module Extensions
+    module ParentTrap
+      # EventMachine and Thin both trap INT when they start their servers. Patch
+      # them to call any previous handler.
+      def trap(*args, &block)
+        parent_trap = super(*args) {
+          yield
+          parent_trap&.call
+        }
+      end
+    end
+  end
+end
+
+EventMachine::WebSocket.singleton_class.prepend PusherFake::Extensions::ParentTrap
+Thin::Server.prepend PusherFake::Extensions::ParentTrap

--- a/lib/pusher-fake/server.rb
+++ b/lib/pusher-fake/server.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "extensions/parent_trap"
+
 module PusherFake
   # Socket and web server manager.
   module Server


### PR DESCRIPTION
This change monkey patches some dependencies to call any existing handlers of `trap` signals when registering their own.

[EventMachine](https://github.com/igrigorik/em-websocket/blob/526aa130586463b90f27716dff6e5f7fb67f4b39/lib/em-websocket/websocket.rb#L33), [Thin](https://github.com/macournoyer/thin/blob/10607a2663fc282d67f98a930f954dc407fd056d/lib/thin/server.rb#L230), and [rspec](https://github.com/rspec/rspec-core/blob/fe3084758857f0714f05ada44a18f1dfe9bf7a7e/lib/rspec/core/runner.rb#L175) all register their own handlers for the INT signal. (among others) None of them consider existing handlers so they end up disabling behavior in the other libraries. I think PusherFake is where this change belongs since it's the intersection of the three?

### Motivation

The specific problem I'm trying to solve is these libraries swallowing up an INT signal that should be received by rspec. Typically interrupting rspec allows it to finish the current test and gracefully shut down:

```
.........^C
RSpec is shutting down and will print the summary report... Interrupt again to force quit.
.

Finished in ...
```

But with PusherFake's server running the interrupt is never received by rspec at all, and the user has to kill the process or wait for the tests to complete on their own:

```
.......^CTerminating WebSocket Server
......^CTerminating WebSocket Server
F..........^CTerminating WebSocket Server
F......

Failures: ...
```