### PR TITLE
Drop support for Ruby 2.7.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Layout/HashAlignment:
   EnforcedColonStyle: table

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add support for Ruby 3.2. (Tristan Dunn)
+* Drop support for Ruby 2.7. (Tristan Dunn)
 * Update development dependencies. (Tristan Dunn)
 
 ## 4.2.0 — August 1st, 2022

--- a/lib/pusher-fake/channel/public.rb
+++ b/lib/pusher-fake/channel/public.rb
@@ -4,7 +4,7 @@ module PusherFake
   module Channel
     # A public channel.
     class Public
-      CACHE_CHANNEL_PREFIX = /^(private-|presence-){0,1}cache-/.freeze
+      CACHE_CHANNEL_PREFIX = /^(private-|presence-){0,1}cache-/
 
       # @return [Array] Connections in this channel.
       attr_reader :connections

--- a/pusher-fake.gemspec
+++ b/pusher-fake.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables << "pusher-fake"
   s.require_path = "lib"
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "em-http-request", "~> 1.1"
   s.add_dependency "em-websocket",    "~> 0.5"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ if ENV["CI"] || ENV["COVERAGE"]
   end
 end
 
-Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each do |file|
+Dir[File.expand_path("support/**/*.rb", __dir__)].each do |file|
   require file
 end
 


### PR DESCRIPTION
Ruby 2.7 has an [end of life of March 31st, 2023](https://endoflife.date/ruby).