### PR TITLE
Update thin to 2.0

### DIFF
--- a/pusher-fake.gemspec
+++ b/pusher-fake.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency "em-websocket",    "~> 0.5"
   s.add_dependency "multi_json",      "~> 1.6"
   s.add_dependency "mutex_m",         "~> 0.3.0"
-  s.add_dependency "thin",            ">= 1.8", "< 2"
+  s.add_dependency "thin",            ">= 1.8", "~> 2.0.0"
 end


### PR DESCRIPTION
The dependency on thin 1.0 (which uses rack < 3) blocks upgrades for rack, sinatra, and puma. This PR updates the thin dependency to a 2.0 release.